### PR TITLE
게시글 목록 조회, 검색 기능 보완

### DIFF
--- a/module-client/src/main/java/com/example/moduleclient/constant/SearchType.java
+++ b/module-client/src/main/java/com/example/moduleclient/constant/SearchType.java
@@ -1,0 +1,12 @@
+package com.example.moduleclient.constant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum SearchType {
+	N("닉네임"), T("제목"), C("내용");
+
+	public String name;
+}

--- a/module-client/src/main/java/com/example/moduleclient/post/PostController.java
+++ b/module-client/src/main/java/com/example/moduleclient/post/PostController.java
@@ -6,7 +6,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
@@ -17,12 +16,11 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
 
 import com.example.moduleclient.constant.Category;
+import com.example.moduleclient.constant.SearchType;
 import com.example.moduleclient.reply.ReplyResponse;
 import com.example.moduleclient.reply.ReplyService;
-import com.example.modulecore.util.ApiUtil;
 
 import lombok.RequiredArgsConstructor;
 
@@ -35,11 +33,22 @@ public class PostController {
 	@GetMapping("/boards")
 	public String list(
 		@RequestParam(required = false, defaultValue = "0", value = "page") int pageNo,
+		@RequestParam(defaultValue = "GENERAL") Category category,
+		@RequestParam(required = false, name = "type") SearchType searchType,
+		@RequestParam(required = false) String keyword,
 		@AuthenticationPrincipal UserDetails userDetails, Model model,
 		@PageableDefault(size = 6, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
 
-		Page<PostPagesDto> postPages = postService.list(pageNo, Category.GENERAL, pageable);
+		Page<PostPagesDto> postPages = null;
+		if (keyword == null) {
+			postPages = postService.list(pageNo, category, pageable);
+		} else {
+			postPages = postService.searchPosts(pageNo, searchType, keyword, category, pageable);
+		}
+
 		model.addAttribute("list", postPages);
+		model.addAttribute("searchType", SearchType.values());
+		model.addAttribute("categories", Category.values());
 
 		return "board/list";
 	}
@@ -91,12 +100,5 @@ public class PostController {
 		PostResponse.UpdateDto updateRespDto = postService.updatePost(updateReqDto, id);
 
 		return "redirect:/boards/{id}";
-	}
-
-	@GetMapping("/boards/search")
-	@ResponseBody
-	public ResponseEntity<?> searchPosts(@RequestParam int gubun, @RequestParam String keyword) {
-		Page<PostPagesDto> postPages = postService.searchByKeyword(0, gubun, keyword);
-		return ResponseEntity.ok().body(ApiUtil.success(postPages));
 	}
 }

--- a/module-client/src/main/java/com/example/moduleclient/post/PostController.java
+++ b/module-client/src/main/java/com/example/moduleclient/post/PostController.java
@@ -22,6 +22,7 @@ import com.example.moduleclient.constant.SearchType;
 import com.example.moduleclient.reply.ReplyResponse;
 import com.example.moduleclient.reply.ReplyService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @Controller
@@ -73,7 +74,7 @@ public class PostController {
 	}
 
 	@PostMapping("/api/board/save")
-	public String savePost(PostRequest.saveDto saveReqDto,
+	public String savePost(@Valid PostRequest.saveDto saveReqDto,
 		@AuthenticationPrincipal UserDetails userDetails) {
 		PostResponse.SaveDto saveRespDto = postService.savePost(saveReqDto, userDetails.getUsername());
 		return "redirect:/boards/" + saveRespDto.getId();
@@ -96,7 +97,7 @@ public class PostController {
 	}
 
 	@PutMapping("/api/boards/{id}/update")
-	public String updatePost(@PathVariable Long id, PostRequest.UpdateDto updateReqDto) {
+	public String updatePost(@PathVariable Long id, @Valid PostRequest.UpdateDto updateReqDto) {
 		PostResponse.UpdateDto updateRespDto = postService.updatePost(updateReqDto, id);
 
 		return "redirect:/boards/{id}";

--- a/module-client/src/main/java/com/example/moduleclient/post/PostPagesDto.java
+++ b/module-client/src/main/java/com/example/moduleclient/post/PostPagesDto.java
@@ -14,6 +14,8 @@ import lombok.Setter;
 public class PostPagesDto {
 	private Long id;
 	private String title;
+	private String content;
+	private String thumbnail;
 	private String nickname;
 	private LocalDateTime createdAt;
 }

--- a/module-client/src/main/java/com/example/moduleclient/post/PostRepository.java
+++ b/module-client/src/main/java/com/example/moduleclient/post/PostRepository.java
@@ -9,22 +9,26 @@ import org.springframework.data.repository.query.Param;
 import com.example.moduleclient.constant.Category;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
-	@Query("SELECT new com.example.moduleclient.post.PostPagesDto(p.id, p.title, u.nickname, p.createdAt)"
-		+ " FROM Post p JOIN p.member u WHERE p.category = :category")
+	@Query(
+		"SELECT new com.example.moduleclient.post.PostPagesDto(p.id, p.title, p.content, p.thumbnail, u.nickname, p.createdAt)"
+			+ " FROM Post p JOIN p.member u WHERE p.category = :category")
 	Page<PostPagesDto> findByCategory(@Param("category") Category category, Pageable pageable);
 
-	@Query("SELECT new com.example.moduleclient.post.PostPagesDto(p.id, p.title, u.nickname, p.createdAt)"
-		+ " FROM Post p JOIN p.member u WHERE p.category = :category AND u.nickname LIKE %:keyword%")
+	@Query(
+		"SELECT new com.example.moduleclient.post.PostPagesDto(p.id, p.title, p.content, p.thumbnail, u.nickname, p.createdAt)"
+			+ " FROM Post p JOIN p.member u WHERE p.category = :category AND u.nickname LIKE %:keyword%")
 	Page<PostPagesDto> findByNicknameContaining(@Param("keyword") String keyword, @Param("category") Category category,
 		Pageable pageable);
 
-	@Query("SELECT new com.example.moduleclient.post.PostPagesDto(p.id, p.title, u.nickname, p.createdAt)"
-		+ " FROM Post p JOIN p.member u WHERE p.category = :category AND p.title LIKE %:keyword%")
+	@Query(
+		"SELECT new com.example.moduleclient.post.PostPagesDto(p.id, p.title, p.content, p.thumbnail, u.nickname, p.createdAt)"
+			+ " FROM Post p JOIN p.member u WHERE p.category = :category AND p.title LIKE %:keyword%")
 	Page<PostPagesDto> findByTitleContaining(@Param("keyword") String keyword, @Param("category") Category category,
 		Pageable pageable);
 
-	@Query("SELECT new com.example.moduleclient.post.PostPagesDto(p.id, p.title, u.nickname, p.createdAt)"
-		+ " FROM Post p JOIN p.member u WHERE p.category = :category AND p.content LIKE %:keyword%")
+	@Query(
+		"SELECT new com.example.moduleclient.post.PostPagesDto(p.id, p.title, p.content, p.thumbnail, u.nickname, p.createdAt)"
+			+ " FROM Post p JOIN p.member u WHERE p.category = :category AND p.content LIKE %:keyword%")
 	Page<PostPagesDto> findByContentContaining(@Param("keyword") String keyword, @Param("category") Category category,
 		Pageable pageable);
 }

--- a/module-client/src/main/java/com/example/moduleclient/post/PostRepository.java
+++ b/module-client/src/main/java/com/example/moduleclient/post/PostRepository.java
@@ -14,14 +14,17 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 	Page<PostPagesDto> findByCategory(@Param("category") Category category, Pageable pageable);
 
 	@Query("SELECT new com.example.moduleclient.post.PostPagesDto(p.id, p.title, u.nickname, p.createdAt)"
-		+ " FROM Post p JOIN p.member u WHERE u.nickname LIKE %:keyword%")
-	Page<PostPagesDto> findByNicknameContaining(@Param("keyword") String keyword, Pageable pageable);
+		+ " FROM Post p JOIN p.member u WHERE p.category = :category AND u.nickname LIKE %:keyword%")
+	Page<PostPagesDto> findByNicknameContaining(@Param("keyword") String keyword, @Param("category") Category category,
+		Pageable pageable);
 
 	@Query("SELECT new com.example.moduleclient.post.PostPagesDto(p.id, p.title, u.nickname, p.createdAt)"
-		+ " FROM Post p JOIN p.member u WHERE p.title LIKE %:keyword%")
-	Page<PostPagesDto> findByTitleContaining(@Param("keyword") String keyword, Pageable pageable);
+		+ " FROM Post p JOIN p.member u WHERE p.category = :category AND p.title LIKE %:keyword%")
+	Page<PostPagesDto> findByTitleContaining(@Param("keyword") String keyword, @Param("category") Category category,
+		Pageable pageable);
 
 	@Query("SELECT new com.example.moduleclient.post.PostPagesDto(p.id, p.title, u.nickname, p.createdAt)"
-		+ " FROM Post p JOIN p.member u WHERE p.content LIKE %:keyword%")
-	Page<PostPagesDto> findByContentContaining(@Param("keyword") String keyword, Pageable pageable);
+		+ " FROM Post p JOIN p.member u WHERE p.category = :category AND p.content LIKE %:keyword%")
+	Page<PostPagesDto> findByContentContaining(@Param("keyword") String keyword, @Param("category") Category category,
+		Pageable pageable);
 }

--- a/module-client/src/main/java/com/example/moduleclient/post/PostRequest.java
+++ b/module-client/src/main/java/com/example/moduleclient/post/PostRequest.java
@@ -5,6 +5,7 @@ import com.example.moduleclient.constant.Status;
 import com.example.moduleclient.member.Member;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -25,7 +26,7 @@ public class PostRequest {
 		private String content;
 
 		private String thumbnail;
-		@NotBlank
+		@NotNull
 		private Category category;
 
 		public Post toEntity(Member member) {

--- a/module-client/src/main/java/com/example/moduleclient/post/PostService.java
+++ b/module-client/src/main/java/com/example/moduleclient/post/PostService.java
@@ -1,12 +1,11 @@
 package com.example.moduleclient.post;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import com.example.moduleclient.constant.Category;
+import com.example.moduleclient.constant.SearchType;
 import com.example.moduleclient.member.Member;
 import com.example.moduleclient.member.MemberRepository;
 
@@ -23,6 +22,23 @@ public class PostService {
 	public Page<PostPagesDto> list(int pageNo, Category category, Pageable pageable) {
 		pageNo = pageNo == 0 ? 0 : pageNo - 1;
 		Page<PostPagesDto> postPagesRespDto = postRepository.findByCategory(category, pageable);
+
+		return postPagesRespDto;
+	}
+
+	public Page<PostPagesDto> searchPosts(int pageNo, SearchType searchType, String keyword, Category category,
+		Pageable pageable) {
+		pageNo = pageNo == 0 ? 0 : pageNo - 1;
+
+		Page<PostPagesDto> postPagesRespDto = null;
+
+		if (searchType == SearchType.T) {
+			postPagesRespDto = postRepository.findByTitleContaining(keyword, category, pageable);
+		} else if (searchType == SearchType.C) {
+			postPagesRespDto = postRepository.findByContentContaining(keyword, category, pageable);
+		} else if (searchType == SearchType.N) {
+			postPagesRespDto = postRepository.findByNicknameContaining(keyword, category, pageable);
+		}
 
 		return postPagesRespDto;
 	}
@@ -60,27 +76,6 @@ public class PostService {
 		PostResponse.UpdateDto updateRespDto = new PostResponse.UpdateDto(post);
 
 		return updateRespDto;
-	}
-
-	public Page<PostPagesDto> searchByKeyword(int pageNo, int gubun, String keyword) {
-		Pageable pageable = PageRequest.of(pageNo, 6, Sort.by(Sort.Direction.DESC, "id"));
-		Page<PostPagesDto> postPagesRespDto = null;
-
-		switch (gubun) {
-			case 1:
-				postPagesRespDto = postRepository.findByNicknameContaining(keyword, pageable);
-				break;
-
-			case 2:
-				postPagesRespDto = postRepository.findByTitleContaining(keyword, pageable);
-				break;
-
-			case 3:
-				postPagesRespDto = postRepository.findByContentContaining(keyword, pageable);
-				break;
-		}
-
-		return postPagesRespDto;
 	}
 
 	public PostRequest.UpdateDto findById(Long id) {

--- a/module-client/src/main/java/com/example/moduleclient/reply/ReplyController.java
+++ b/module-client/src/main/java/com/example/moduleclient/reply/ReplyController.java
@@ -6,7 +6,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import com.example.modulecore.util.ApiUtil;
@@ -18,7 +18,7 @@ import lombok.RequiredArgsConstructor;
 public class ReplyController {
 	private final ReplyService replyService;
 
-	@PutMapping("/reply/insert")
+	@PostMapping("/reply/insert")
 	public ResponseEntity<?> insertReply(@RequestBody ReplyRequest.saveDto saveReqDto, @AuthenticationPrincipal
 	UserDetails userDetails) {
 		ReplyResponse.SaveDto saveRespDto = replyService.saveReply(saveReqDto, userDetails.getUsername());

--- a/module-client/src/main/resources/templates/board/list.html
+++ b/module-client/src/main/resources/templates/board/list.html
@@ -35,18 +35,21 @@
     <div th:each="board: ${list}" class="col">
       <div th:onclick="|location.href='@{/boards/{id} (id=${board.id})}'|" class="card"
            style="width: 18rem; cursor: pointer">
-        <svg class="bd-placeholder-img card-img-top" width="100%" height="180" xmlns="http://www.w3.org/2000/svg"
+        <svg th:if="${board.thumbnail == null}" class="bd-placeholder-img card-img-top" width="100%" height="180"
+             xmlns="http://www.w3.org/2000/svg"
              role="img"
              aria-label="Placeholder: Image cap" preserveAspectRatio="xMidYMid slice" focusable="false">
           <title>Placeholder</title>
           <rect width="100%" height="100%" fill="#868e96"></rect>
-          <text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text>
+          <text x="50%" y="50%" fill="#dee2e6" dy=".3em">No Image</text>
         </svg>
+        <img th:unless="${board.thumbnail == null}" src="${board.thumbnail}" class="card-img-top" alt="thumbnail">
         <div class="card-body">
           <h5 class="card-title" th:text="${board.title}"></h5>
+          <p class="d-inline-block text-truncate" style="max-width: 100%;" th:text="${board.content}"></p>
           <p class="card-text" th:text="${board.nickname}"></p>
         </div>
-        <div class="card-footer">
+        <div class="card-footer text-end">
           <small class="text-muted" th:text="${board.createdAt}"></small>
         </div>
       </div>
@@ -72,7 +75,7 @@
                     end=(${start + 5 < list.totalPages ? start + 5 : list.totalPages})"
             th:each="pageButton : ${#numbers.sequence(start, end)}">
           <a class="page-link" th:href="@{/boards?page={page} (page = ${pageButton})}"
-             th:text=${pageButton}></a>
+             th:text="${pageButton}"></a>
         </li>
       </th:block>
       <li class="page-item">

--- a/module-client/src/main/resources/templates/board/list.html
+++ b/module-client/src/main/resources/templates/board/list.html
@@ -1,74 +1,92 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link href="https://getbootstrap.com/docs/5.2/assets/css/docs.css" rel="stylesheet">
-  <title>목록</title>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
-</head>
-<body class="container">
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/basic.html}">
 
-<div class="jumbotron">
-  <h2>게시판</h2>
-</div>
-<div class="row row-cols-1 row-cols-md-3 g-6">
-  <div th:each="board: ${list}" class="col" onclick="location.href='/board/${board.id}'" style="cursor: pointer">
-    <div class="card" style="width: 18rem;">
-      <svg class="bd-placeholder-img card-img-top" width="100%" height="180" xmlns="http://www.w3.org/2000/svg"
-           role="img"
-           aria-label="Placeholder: Image cap" preserveAspectRatio="xMidYMid slice" focusable="false">
-        <title>Placeholder</title>
-        <rect width="100%" height="100%" fill="#868e96"></rect>
-        <text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text>
-      </svg>
-      <div class="card-body">
-        <h5 class="card-title" th:text="${board.title}"></h5>
-        <p class="card-text" th:text="${board.nickname}"></p>
+<div layout:fragment="content">
+
+  <div class="row mt-3">
+    <form action="/boards" method="get">
+      <div class="col">
+        <div class="input-group">
+          <div class="input-group-prepend">
+            <select class="form-select" aria-label="Select Category" name="category">
+              <option th:each="category: ${categories}" th:value="${category}"
+                      th:selected="${param.category == category}" th:text="${category.getName()}"></option>
+            </select>
+          </div>
+          <div class="input-group-prepend">
+            <select class="form-select" aria-label="Select Search Type" name="type">
+              <option th:each="type: ${searchType}" th:value="${type}" th:selected="${param.type == type}"
+                      th:text="${type.getName()}"></option>
+            </select>
+          </div>
+          <input type="text" class="form-control" name="keyword" th:value="${param.keyword}">
+          <div class="input-group-append">
+            <button class="btn btn-outline-secondary searchBtn" type="submit">검색</button>
+            <a href="/boards" role="button" class="btn btn-secondary">초기화</a>
+          </div>
+        </div>
       </div>
-      <div class="card-footer">
-        <small class="text-muted" th:text="${board.createdAt}"></small>
+    </form>
+  </div>
+
+  <div class="row row-cols-1 row-cols-md-3 g-6">
+    <div th:each="board: ${list}" class="col">
+      <div th:onclick="|location.href='@{/boards/{id} (id=${board.id})}'|" class="card"
+           style="width: 18rem; cursor: pointer">
+        <svg class="bd-placeholder-img card-img-top" width="100%" height="180" xmlns="http://www.w3.org/2000/svg"
+             role="img"
+             aria-label="Placeholder: Image cap" preserveAspectRatio="xMidYMid slice" focusable="false">
+          <title>Placeholder</title>
+          <rect width="100%" height="100%" fill="#868e96"></rect>
+          <text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text>
+        </svg>
+        <div class="card-body">
+          <h5 class="card-title" th:text="${board.title}"></h5>
+          <p class="card-text" th:text="${board.nickname}"></p>
+        </div>
+        <div class="card-footer">
+          <small class="text-muted" th:text="${board.createdAt}"></small>
+        </div>
       </div>
     </div>
   </div>
-</div>
 
-<nav aria-label="Page navigation example ">
-  <ul class="pagination">
-    <li class="page-item">
-      <a class="page-link" th:href="@{/boards}" aria-label="First">
-        <span aria-hidden="true">처음</span>
-      </a>
-    </li>
-    <li class="page-item">
-      <a class="page-link" th:href="@{/boards?page={page} (page = ${list.number})}" aria-label="Previous">
-        <span aria-hidden="true">이전</span>
-      </a>
-    </li>
-    <th:block th:with="start=${T(java.lang.Math).floor(list.number/6)*6 + 1},
-                    end=(${start + 5 < list.totalPages ? start + 5 : list.totalPages})">
-      <li class="page-item"
-          th:with="start=${T(java.lang.Math).floor(list.number/6)*6 + 1},
-                    end=(${start + 5 < list.totalPages ? start + 5 : list.totalPages})"
-          th:each="pageButton : ${#numbers.sequence(start, end)}">
-        <a class="page-link" th:href="@{/boards?page={page} (page = ${pageButton})}" th:text=${pageButton}></a>
+  <nav aria-label="Page navigation example ">
+    <ul class="pagination">
+      <li class="page-item">
+        <a class="page-link" th:href="@{/boards}" aria-label="First">
+          <span aria-hidden="true">처음</span>
+        </a>
       </li>
-    </th:block>
-    <li class="page-item">
-      <a class="page-link"
-         th:href="@{/boards?page={page} (page = (${T(java.lang.Math).floor(list.number/6)*6 + 1 + 5 < list.totalPages ? T(java.lang.Math).floor(list.number/6)*6 + 1 + 5 : list.totalPages}) + 1)}"
-         aria-label="Next">
-        <span aria-hidden="true">다음</span>
-      </a>
-    </li>
-    <li class="page-item">
-      <a class="page-link" th:href="@{/boards?page={page} (page = ${list.totalPages})}" aria-label="End">
-        <span aria-hidden="true">끝</span>
-      </a>
-    </li>
-  </ul>
-</nav>
-
-</body>
-</html>
+      <li class="page-item">
+        <a class="page-link" th:href="@{/boards?page={page} (page = ${list.number})}" aria-label="Previous">
+          <span aria-hidden="true">이전</span>
+        </a>
+      </li>
+      <th:block th:with="start=${T(java.lang.Math).floor(list.number/6)*6 + 1},
+                    end=(${start + 5 < list.totalPages ? start + 5 : list.totalPages})">
+        <li class="page-item"
+            th:with="start=${T(java.lang.Math).floor(list.number/6)*6 + 1},
+                    end=(${start + 5 < list.totalPages ? start + 5 : list.totalPages})"
+            th:each="pageButton : ${#numbers.sequence(start, end)}">
+          <a class="page-link" th:href="@{/boards?page={page} (page = ${pageButton})}"
+             th:text=${pageButton}></a>
+        </li>
+      </th:block>
+      <li class="page-item">
+        <a class="page-link"
+           th:href="@{/boards?page={page} (page = (${T(java.lang.Math).floor(list.number/6)*6 + 1 + 5 < list.totalPages ? T(java.lang.Math).floor(list.number/6)*6 + 1 + 5 : list.totalPages}) + 1)}"
+           aria-label="Next">
+          <span aria-hidden="true">다음</span>
+        </a>
+      </li>
+      <li class="page-item">
+        <a class="page-link" th:href="@{/boards?page={page} (page = ${list.totalPages})}" aria-label="End">
+          <span aria-hidden="true">끝</span>
+        </a>
+      </li>
+    </ul>
+  </nav>
+</div>


### PR DESCRIPTION
9. 게시글 목록보기
    - [ ]  [게시글 목록보기 페이지] 게시글 목록보기 (id, title, content, thumbnail, user의 nickName 화면에 보여야 함, content내용을 화면에 2줄이 넘어가면 Ellipsis(...)으로 스타일 변경, 정렬은 id순 Desc
        [x] Ellipsis 적용
        [ ] Thumbnail 적용

11. 게시글 검색
    - [x]  [게시글 목록보기 페이지] 작성자(nickName), 제목(title), 내용(content)로 검색가능해야 함.