### PR TITLE
게시글 목록 페이지 수정, SecurityConfig 수정 PR

### DIFF
--- a/module-client/src/main/java/com/example/moduleclient/ClientApplcation.java
+++ b/module-client/src/main/java/com/example/moduleclient/ClientApplcation.java
@@ -2,9 +2,8 @@ package com.example.moduleclient;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
+@SpringBootApplication
 public class ClientApplcation {
 	public static void main(String[] args) {
 		SpringApplication.run(ClientApplcation.class, args);

--- a/module-client/src/main/java/com/example/moduleclient/config/SecurityConfig.java
+++ b/module-client/src/main/java/com/example/moduleclient/config/SecurityConfig.java
@@ -1,70 +1,80 @@
 package com.example.moduleclient.config;
 
-import com.example.moduleclient.service.MemberService;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
+import javax.sql.DataSource;
+
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.rememberme.JdbcTokenRepositoryImpl;
 import org.springframework.security.web.authentication.rememberme.PersistentTokenRepository;
 
-import javax.sql.DataSource;
+import com.example.moduleclient.member.MemberService;
 
-@Configuration
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
 @RequiredArgsConstructor
-@EnableGlobalMethodSecurity(prePostEnabled = true)
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
 @Log4j2
 public class SecurityConfig {
-    private final DataSource dataSource;
-    private final MemberService memberService;
+	private final DataSource dataSource;
+	private final MemberService memberService;
 
-    @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
-        log.info("----------------configure-------------------------");
+		log.info("----------------configure-------------------------");
 
-        http.formLogin().loginPage("/member/login");
-        http.csrf().disable();
+		http.formLogin((formLogin) -> formLogin.loginPage("/member/login").defaultSuccessUrl("/"));
+		http.csrf(AbstractHttpConfigurer::disable);
 
-        //자동 로그인
-        http.rememberMe()
-                .key("12345678")
-                .tokenRepository(persistentTokenRepository())
-                .userDetailsService(memberService)
-                .tokenValiditySeconds(60*60*24*30);
+		http.rememberMe(httpSecurityRememberMeConfigurer -> httpSecurityRememberMeConfigurer.key("12345678")
+			.tokenRepository(persistentTokenRepository())
+			.userDetailsService(memberService)
+			.tokenValiditySeconds(60 * 60 * 24 * 30));
 
-        return http.build();
-    }
+		http.logout(logout -> logout.logoutSuccessUrl("/member/login"));
 
-    //자동 로그인 쿠키 값 인코딩을 위한 키 값, 정보 저장 메서드
-    @Bean
-    public PersistentTokenRepository persistentTokenRepository(){
+		http.authorizeHttpRequests(auth -> auth
+			.requestMatchers(HttpMethod.GET, "/member/login", "/member/join").permitAll()
+			.anyRequest().authenticated());
 
-        JdbcTokenRepositoryImpl repo= new JdbcTokenRepositoryImpl();
-        repo.setDataSource(dataSource);
+		return http.build();
+	}
 
-        return repo;
-    }
+	//자동 로그인 쿠키 값 인코딩을 위한 키 값, 정보 저장 메서드
+	@Bean
+	public PersistentTokenRepository persistentTokenRepository() {
 
-    @Bean
-    public PasswordEncoder PasswordEncoder () {
+		JdbcTokenRepositoryImpl repo = new JdbcTokenRepositoryImpl();
+		repo.setDataSource(dataSource);
 
-        return new BCryptPasswordEncoder();
-    }
+		return repo;
+	}
 
-    //정적자원 시큐리티 적용 제외(ex. css)
-    @Bean
-    public WebSecurityCustomizer webSecurityCustomizer(){
+	@Bean
+	public PasswordEncoder PasswordEncoder() {
 
-        log.info("----------------web configure-----------------------------");
+		return new BCryptPasswordEncoder();
+	}
 
-        return (web) -> web.ignoring().requestMatchers(PathRequest.toStaticResources().atCommonLocations());
-    }
+	//정적자원 시큐리티 적용 제외(ex. css)
+	@Bean
+	public WebSecurityCustomizer webSecurityCustomizer() {
+
+		log.info("----------------web configure-----------------------------");
+
+		return (web) -> web.ignoring().requestMatchers(PathRequest.toStaticResources().atCommonLocations());
+	}
 }

--- a/module-client/src/main/java/com/example/moduleclient/post/PostController.java
+++ b/module-client/src/main/java/com/example/moduleclient/post/PostController.java
@@ -4,8 +4,6 @@ import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
@@ -31,15 +29,14 @@ public class PostController {
 	private final PostService postService;
 	private final ReplyService replyService;
 
-	@GetMapping("/boards")
+	@GetMapping({"/boards", "/"})
 	public String list(
 		@RequestParam(required = false, defaultValue = "0", value = "page") int pageNo,
-		@RequestParam(defaultValue = "GENERAL") Category category,
-		@RequestParam(required = false, name = "type") SearchType searchType,
-		@RequestParam(required = false) String keyword,
-		@AuthenticationPrincipal UserDetails userDetails, Model model,
-		@PageableDefault(size = 6, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+		@RequestParam(defaultValue = "GENERAL")
+		Category category, @RequestParam(required = false, name = "type") SearchType searchType,
+		@RequestParam(required = false) String keyword, Model model, Pageable pageable) {
 
+		pageNo = pageNo == 0 ? 0 : pageNo - 1;
 		Page<PostPagesDto> postPages = null;
 		if (keyword == null) {
 			postPages = postService.list(pageNo, category, pageable);

--- a/module-client/src/main/java/com/example/moduleclient/post/PostRequest.java
+++ b/module-client/src/main/java/com/example/moduleclient/post/PostRequest.java
@@ -1,5 +1,7 @@
 package com.example.moduleclient.post;
 
+import org.springframework.web.multipart.MultipartFile;
+
 import com.example.moduleclient.constant.Category;
 import com.example.moduleclient.constant.Status;
 import com.example.moduleclient.member.Member;
@@ -26,6 +28,8 @@ public class PostRequest {
 		private String content;
 
 		private String thumbnail;
+		private MultipartFile thumbnailImage;
+
 		@NotNull
 		private Category category;
 

--- a/module-client/src/main/java/com/example/moduleclient/post/PostService.java
+++ b/module-client/src/main/java/com/example/moduleclient/post/PostService.java
@@ -1,7 +1,9 @@
 package com.example.moduleclient.post;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -22,7 +24,8 @@ public class PostService {
 	private final EntityManager entityManager;
 
 	public Page<PostPagesDto> list(int pageNo, Category category, Pageable pageable) {
-		pageNo = pageNo == 0 ? 0 : pageNo - 1;
+		pageable = PageRequest.of(pageNo, 6, Sort.by("id").descending());
+
 		Page<PostPagesDto> postPagesRespDto = postRepository.findByCategory(category, pageable);
 
 		return postPagesRespDto;
@@ -30,8 +33,8 @@ public class PostService {
 
 	public Page<PostPagesDto> searchPosts(int pageNo, SearchType searchType, String keyword, Category category,
 		Pageable pageable) {
-		pageNo = pageNo == 0 ? 0 : pageNo - 1;
 
+		pageable = PageRequest.of(pageNo, 6, Sort.by("id").descending());
 		Page<PostPagesDto> postPagesRespDto = null;
 
 		if (searchType == SearchType.T) {

--- a/module-client/src/main/java/com/example/moduleclient/post/PostService.java
+++ b/module-client/src/main/java/com/example/moduleclient/post/PostService.java
@@ -3,11 +3,13 @@ package com.example.moduleclient.post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.example.moduleclient.constant.Category;
 import com.example.moduleclient.constant.SearchType;
 import com.example.moduleclient.member.Member;
 import com.example.moduleclient.member.MemberRepository;
+import com.example.modulecore.image.ImageUpload;
 
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
@@ -53,6 +55,10 @@ public class PostService {
 
 	public PostResponse.SaveDto savePost(PostRequest.saveDto saveReqDto, String username) {
 		Member member = memberRepository.findByUsername(username);
+
+		String uploadThumbnail = getUploadThumbnail(saveReqDto.getThumbnailImage());
+		saveReqDto.setThumbnail(uploadThumbnail);
+
 		Post post = postRepository.save(saveReqDto.toEntity(member));
 
 		return new PostResponse.SaveDto(post);
@@ -82,5 +88,12 @@ public class PostService {
 		Post post = postRepository.findById(id).orElseThrow();
 
 		return new PostRequest.UpdateDto(post);
+	}
+
+	private String getUploadThumbnail(MultipartFile originThumbnail) {
+		if (originThumbnail == null)
+			return null;
+
+		return ImageUpload.upload(originThumbnail, "thumbnails");
 	}
 }

--- a/module-client/src/main/resources/templates/board/list.html
+++ b/module-client/src/main/resources/templates/board/list.html
@@ -5,20 +5,20 @@
 
 <div layout:fragment="content">
 
-  <div class="row mt-3">
+  <div class="row mt-3" style="padding-bottom: 2%;">
     <form action="/boards" method="get">
       <div class="col">
         <div class="input-group">
           <div class="input-group-prepend">
-            <select class="form-select" aria-label="Select Category" name="category">
-              <option th:each="category: ${categories}" th:value="${category}"
-                      th:selected="${param.category == category}" th:text="${category.getName()}"></option>
+            <select class="form-select" aria-label="Select Category" name="category" onchange="this.form.submit()">
+              <option th:each="category: ${categories}" th:value="${category}" th:text="${category.getName()}"
+                      th:selected="${param.category} == ${category}"></option>
             </select>
           </div>
           <div class="input-group-prepend">
             <select class="form-select" aria-label="Select Search Type" name="type">
-              <option th:each="type: ${searchType}" th:value="${type}" th:selected="${param.type == type}"
-                      th:text="${type.getName()}"></option>
+              <option th:each="type: ${searchType}" th:value="${type}" th:text="${type.getName()}"
+                      th:selected="${param.type == type}"></option>
             </select>
           </div>
           <input type="text" class="form-control" name="keyword" th:value="${param.keyword}">
@@ -32,7 +32,7 @@
   </div>
 
   <div class="row row-cols-1 row-cols-md-3 g-6">
-    <div th:each="board: ${list}" class="col">
+    <div th:each="board: ${list}" class="col" style="padding-bottom: 3%;">
       <div th:onclick="|location.href='@{/boards/{id} (id=${board.id})}'|" class="card"
            style="width: 18rem; cursor: pointer">
         <svg th:if="${board.thumbnail == null}" class="bd-placeholder-img card-img-top" width="100%" height="180"
@@ -41,10 +41,10 @@
              aria-label="Placeholder: Image cap" preserveAspectRatio="xMidYMid slice" focusable="false">
           <title>Placeholder</title>
           <rect width="100%" height="100%" fill="#868e96"></rect>
-          <text x="50%" y="50%" fill="#dee2e6" dy=".3em">No Image</text>
+          <text x="50%" y="50%" fill="#dee2e6">No Image</text>
         </svg>
-        <img th:unless="${board.thumbnail == null}" th:src="@{{path} (path=${board.thumbnail})}" class="card-img-top"
-             alt="thumbnail">
+        <img th:unless="${board.thumbnail == null}" th:src="${board.thumbnail}" class="card-img-top" width="100%"
+             height="180">
         <div class="card-body">
           <h5 class="card-title" th:text="${board.title}"></h5>
           <p class="d-inline-block text-truncate" style="max-width: 100%;" th:text="${board.content}"></p>
@@ -57,40 +57,45 @@
     </div>
   </div>
 
-  <nav aria-label="Page navigation example ">
-    <ul class="pagination">
-      <li class="page-item">
-        <a class="page-link" th:href="@{/boards}" aria-label="First">
-          <span aria-hidden="true">처음</span>
-        </a>
-      </li>
-      <li class="page-item">
-        <a class="page-link" th:href="@{/boards?page={page} (page = ${list.number})}" aria-label="Previous">
-          <span aria-hidden="true">이전</span>
-        </a>
-      </li>
-      <th:block th:with="start=${T(java.lang.Math).floor(list.number/6)*6 + 1},
-                    end=(${start + 5 < list.totalPages ? start + 5 : list.totalPages})">
-        <li class="page-item"
-            th:with="start=${T(java.lang.Math).floor(list.number/6)*6 + 1},
-                    end=(${start + 5 < list.totalPages ? start + 5 : list.totalPages})"
-            th:each="pageButton : ${#numbers.sequence(start, end)}">
-          <a class="page-link" th:href="@{/boards?page={page} (page = ${pageButton})}"
-             th:text="${pageButton}"></a>
+  <div style="padding-top: 3%;">
+    <a href="/board/save" role="button" class="btn btn-primary">글쓰기</a>
+  </div>
+  <div style="padding-top: 1%">
+    <nav aria-label="Page navigation example ">
+      <ul class="pagination">
+        <li class="page-item">
+          <a class="page-link" th:href="@{/boards}" aria-label="First">
+            <span aria-hidden="true">처음</span>
+          </a>
         </li>
-      </th:block>
-      <li class="page-item">
-        <a class="page-link"
-           th:href="@{/boards?page={page} (page = (${T(java.lang.Math).floor(list.number/6)*6 + 1 + 5 < list.totalPages ? T(java.lang.Math).floor(list.number/6)*6 + 1 + 5 : list.totalPages}) + 1)}"
-           aria-label="Next">
-          <span aria-hidden="true">다음</span>
-        </a>
-      </li>
-      <li class="page-item">
-        <a class="page-link" th:href="@{/boards?page={page} (page = ${list.totalPages})}" aria-label="End">
-          <span aria-hidden="true">끝</span>
-        </a>
-      </li>
-    </ul>
-  </nav>
+        <li class="page-item">
+          <a class="page-link" th:href="@{/boards?page={page} (page = ${list.number})}" aria-label="Previous">
+            <span aria-hidden="true">이전</span>
+          </a>
+        </li>
+        <th:block th:with="start=${T(java.lang.Math).floor(list.number/6)*6 + 1},
+                    end=(${start + 5 < list.totalPages ? start + 5 : list.totalPages})">
+          <li class="page-item"
+              th:with="start=${T(java.lang.Math).floor(list.number/6)*6 + 1},
+                    end=(${start + 5 < list.totalPages ? start + 5 : list.totalPages})"
+              th:each="pageButton : ${#numbers.sequence(start, end)}">
+            <a class="page-link" th:href="@{/boards?page={page} (page = ${pageButton})}"
+               th:text="${pageButton}"></a>
+          </li>
+        </th:block>
+        <li class="page-item">
+          <a class="page-link"
+             th:href="@{/boards?page={page} (page = (${T(java.lang.Math).floor(list.number/6)*6 + 1 + 5 < list.totalPages ? T(java.lang.Math).floor(list.number/6)*6 + 1 + 5 : list.totalPages}) + 1)}"
+             aria-label="Next">
+            <span aria-hidden="true">다음</span>
+          </a>
+        </li>
+        <li class="page-item">
+          <a class="page-link" th:href="@{/boards?page={page} (page = ${list.totalPages})}" aria-label="End">
+            <span aria-hidden="true">끝</span>
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </div>
 </div>

--- a/module-client/src/main/resources/templates/board/list.html
+++ b/module-client/src/main/resources/templates/board/list.html
@@ -43,7 +43,8 @@
           <rect width="100%" height="100%" fill="#868e96"></rect>
           <text x="50%" y="50%" fill="#dee2e6" dy=".3em">No Image</text>
         </svg>
-        <img th:unless="${board.thumbnail == null}" src="${board.thumbnail}" class="card-img-top" alt="thumbnail">
+        <img th:unless="${board.thumbnail == null}" th:src="@{{path} (path=${board.thumbnail})}" class="card-img-top"
+             alt="thumbnail">
         <div class="card-body">
           <h5 class="card-title" th:text="${board.title}"></h5>
           <p class="d-inline-block text-truncate" style="max-width: 100%;" th:text="${board.content}"></p>

--- a/module-client/src/main/resources/templates/board/save.html
+++ b/module-client/src/main/resources/templates/board/save.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html>
-<html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -11,7 +10,7 @@
 </head>
 <body>
 <h1>게시글 등록</h1>
-<form th:object="${saveReqDto}" action="/api/board/save" method="post">
+<form th:object="${saveReqDto}" action="/api/board/save" method="post" enctype="multipart/form-data">
   <div class="mb-3">
     <label for="category" class="form-label">카테고리</label>
     <select class="form-select" aria-label="Default select example" id="category" th:field="*{category}">
@@ -28,11 +27,18 @@
   </div>
   <div class="mb-3">
     <label for="thumbnail" class="form-label">썸네일</label>
-    <input class="form-control" type="file" id="thumbnail" th:field="*{thumbnail}">
+    <input class="form-control" type="file" accept="image/*" id="thumbnail" th:field="*{thumbnailImage}">
   </div>
   <a href="/" role="button" class="btn btn-secondary">취소</a>
   <button type="submit" class="btn btn-primary" id="btn-save">등록</button>
 </form>
-
 </body>
+
+<script>
+    $(document).ready(function () {
+        $('#thumbnail').on('change', function () {
+            $('#thumbnail-label').text($(this).val());
+        });
+    });
+</script>
 </html>

--- a/module-core/src/main/java/com/example/modulecore/image/ImageUpload.java
+++ b/module-core/src/main/java/com/example/modulecore/image/ImageUpload.java
@@ -9,13 +9,13 @@ import java.util.UUID;
 import org.springframework.web.multipart.MultipartFile;
 
 public class ImageUpload {
-	private static final String rootPath = System.getProperty("user.dir");
+	private static final String rootPath = System.getProperty("user.dir") + "/module-client/src/main/resources/static/";
 
 	public static String upload(MultipartFile originImage, String directory) {
 		String uploadImageName = UUID.randomUUID().toString() + "_" + originImage.getOriginalFilename();
-		String uploadImagePath = rootPath + File.separator + directory + File.separator;
+		String uploadImagePath = directory + File.separator;
 
-		Path uploadPath = Paths.get(uploadImagePath + uploadImageName);
+		Path uploadPath = Paths.get(rootPath.replace("/", File.separator) + uploadImagePath + uploadImageName);
 
 		try {
 			originImage.transferTo(uploadPath.toFile());

--- a/module-core/src/main/java/com/example/modulecore/image/ImageUpload.java
+++ b/module-core/src/main/java/com/example/modulecore/image/ImageUpload.java
@@ -1,0 +1,28 @@
+package com.example.modulecore.image;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public class ImageUpload {
+	private static final String rootPath = System.getProperty("user.dir");
+
+	public static String upload(MultipartFile originImage, String directory) {
+		String uploadImageName = UUID.randomUUID().toString() + "_" + originImage.getOriginalFilename();
+		String uploadImagePath = rootPath + File.separator + directory + File.separator;
+
+		Path uploadPath = Paths.get(uploadImagePath + uploadImageName);
+
+		try {
+			originImage.transferTo(uploadPath.toFile());
+		} catch (IOException e) {
+			return null;
+		}
+
+		return uploadImagePath + uploadImageName;
+	}
+}


### PR DESCRIPTION
9. 게시글 목록보기
    - [x]  [게시글 목록보기 페이지] 게시글 목록보기 (id, title, content, thumbnail, user의 nickName 화면에 보여야 함, content내용을 화면에 2줄이 넘어가면 Ellipsis(...)으로 스타일 변경, 정렬은 id순 Desc


SecurityConfig 수정
    - Spring Security 6 문법 적용
    - logout 시, 로그인 페이지로 이동
    - 로그인, 회원가입 외 모든 페이지, API 인증여부 체크 (로그인 안되어있는데 게시글 목록이나 상세조회 등 모든 접근 안됨)